### PR TITLE
Reapply "chore(deps): bump org.graalvm.buildtools.native from 0.11.5 …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
-    id("org.graalvm.buildtools.native") version "0.11.5"
+    id("org.graalvm.buildtools.native") version "1.0.0"
 }
 
 group = "com.mpalourdio.projects"


### PR DESCRIPTION
…to 1.0.0"

This reverts commit fabfbd929d5b3358740d4ca21b816b1270f8e610.